### PR TITLE
plot networks w/o edges

### DIFF
--- a/R/plot_network.R
+++ b/R/plot_network.R
@@ -11,11 +11,12 @@
 #' @param layout_type network plot layout. Fruchterman-Reingold, Circular, or Both [fr / c / both]
 #' @param outdir directory where image files will be saved
 #' @param file_suffix string to be added to the suffix of the image file name. script will automatically name the files by port group, year, and layout type.
+#' @param verbose print out a message at the end of the function that includes the port name and year. Helpful when using lapply.
 #' @return Null. Will write plots directly to files
 #' @examples
 #' plot_network(tmpgraph, layout_type="both", outdir="data/networks/participation/plots")
 #' @export
-plot_network <- function(g, layout_type, outdir, file_suffix="_cciea"){
+plot_network <- function(g, layout_type, outdir, file_suffix="_cciea", verbose=FALSE){
   port_group <- unique(V(g)$p)
   y <- unique(V(g)$year)
   if(layout_type=="fr" | layout_type=="both"){
@@ -24,7 +25,6 @@ plot_network <- function(g, layout_type, outdir, file_suffix="_cciea"){
     l <- cbind(l, 1:vcount(g))           # switched from a solid number to a function to get number of vertices -- M.F. 11/19/2018
     rownames(l) <- V(g)$name
     png(here::here(outdir, paste0(port_group,"_", y,"_fr",file_suffix,".png")),bg="transparent")  # if this resolution isn't good enough, add: width = 2000, height = 1500,res=300
-    
     if(vcount(g) == 1 | ecount(g) == 0){
       plot(g, vertex.size = V(g)$importance/(max(V(g)$importance)*0.02), 
            layout = l, #where to put the nodes on the plot
@@ -41,17 +41,10 @@ plot_network <- function(g, layout_type, outdir, file_suffix="_cciea"){
            # vertex.label.dist = c(-9,-8,-9,-10),               # these can be adjusted manually to make it look nicer, which is super annoying
            # vertex.label.degree = c(pi^(0.9),pi/5,pi/5,pi*1.1) # these can be adjusted manually to make it look nicer, which is super annoying
       )
-      dev.off()
-    }
-    if (layout_type=="c" | layout_type=="both"){
-      l <-layout.circle(g)
-      l <- cbind(l, 1:vcount(g))
-      rownames(l) <- V(g)$name
-      tmpnames <- list(V(g)$name)
-      png(here::here(outdir, paste0(port_group,"_", y,"_circular",file_suffix,".png")),bg="transparent")  # if this resolution isn't good enough, add: width = 2000, height = 1500,res=300
+    } else{
       plot(g, vertex.size = V(g)$importance/(max(V(g)$importance)*0.02), 
            layout = l, #where to put the nodes on the plot
-           #edge.width = sqrt(E(g)$weight)/(0.037*max(sqrt(E(g)$weight))),
+           edge.width = sqrt(E(g)$weight)/(0.037*max(sqrt(E(g)$weight))),
            edge.curved = F, 
            axes = F,
            edge.color = 'gray',
@@ -65,53 +58,58 @@ plot_network <- function(g, layout_type, outdir, file_suffix="_cciea"){
            # vertex.label.dist = c(-9,-8,-9,-10),               # these can be adjusted manually to make it look nicer, which is super annoying
            # vertex.label.degree = c(pi^(0.9),pi/5,pi/5,pi*1.1) # these can be adjusted manually to make it look nicer, which is super annoying
       )
-      dev.off()
-    } 
-  if(!(layout_type %in% c("c","fr","both"))){message("ERROR: don't recognize layout type. try again with [fr/c/both]")}
-    
-  } else{
-      
-        plot(g, vertex.size = V(g)$importance/(max(V(g)$importance)*0.02), 
-         layout = l, #where to put the nodes on the plot
-         edge.width = sqrt(E(g)$weight)/(0.037*max(sqrt(E(g)$weight))),
-         edge.curved = F, 
-         axes = F,
-         edge.color = 'gray',
-         vertex.label = V(g)$common_name,
-         vertex.color =adjustcolor(V(g)$colors, alpha.f=0.90),
-         vertex.label.family = 'sans', 
-         vertex.label.color = "gray25",
-         vertex.label.cex= 1.2, 
-         vertex.frame.color=NA
-         # vertex.label.dist = c(-9,-8,-9,-10),               # these can be adjusted manually to make it look nicer, which is super annoying
-         # vertex.label.degree = c(pi^(0.9),pi/5,pi/5,pi*1.1) # these can be adjusted manually to make it look nicer, which is super annoying
-    )
+    } # ifelse (ecount, vcount)
     dev.off()
-  }
+  } #layout==fr
   if (layout_type=="c" | layout_type=="both"){
     l <-layout.circle(g)
     l <- cbind(l, 1:vcount(g))
     rownames(l) <- V(g)$name
-    tmpnames <- list(V(g)$name)
     png(here::here(outdir, paste0(port_group,"_", y,"_circular",file_suffix,".png")),bg="transparent")  # if this resolution isn't good enough, add: width = 2000, height = 1500,res=300
-    plot(g, vertex.size = V(g)$importance/(max(V(g)$importance)*0.02), 
-         layout = l, #where to put the nodes on the plot
-         edge.width = sqrt(E(g)$weight)/(0.037*max(sqrt(E(g)$weight))),
-         edge.curved = F, 
-         axes = F,
-         edge.color = 'gray',
-         vertex.label = V(g)$common_name,
-         vertex.color =adjustcolor(V(g)$colors, alpha.f=0.90),
-         vertex.label.family = 'sans', 
-         # vertex.label.color = V(g)$colors, # to have same color as vertices
-         vertex.label.color = "gray25",
-         vertex.label.cex= 1.2, 
-         vertex.frame.color=NA
-         # vertex.label.dist = c(-9,-8,-9,-10),               # these can be adjusted manually to make it look nicer, which is super annoying
-         # vertex.label.degree = c(pi^(0.9),pi/5,pi/5,pi*1.1) # these can be adjusted manually to make it look nicer, which is super annoying
-    )
+    if(vcount(g) == 1 | ecount(g) == 0){
+      plot(g, vertex.size = V(g)$importance/(max(V(g)$importance)*0.02), 
+           layout = l, #where to put the nodes on the plot
+           # edge.width = sqrt(E(g)$weight)/(0.037*max(sqrt(E(g)$weight))),
+           edge.curved = F, 
+           axes = F,
+           edge.color = 'gray',
+           vertex.label = V(g)$common_name,
+           vertex.color =adjustcolor(V(g)$colors, alpha.f=0.90),
+           vertex.label.family = 'sans', 
+           # vertex.label.color = V(g)$colors, # to have same color as vertices
+           vertex.label.color = "gray25",
+           vertex.label.cex= 1.2, 
+           vertex.frame.color=NA
+           # vertex.label.dist = c(-9,-8,-9,-10),               # these can be adjusted manually to make it look nicer, which is super annoying
+           # vertex.label.degree = c(pi^(0.9),pi/5,pi/5,pi*1.1) # these can be adjusted manually to make it look nicer, which is super annoying
+      )
+    } else{
+      plot(g, vertex.size = V(g)$importance/(max(V(g)$importance)*0.02), 
+           layout = l, #where to put the nodes on the plot
+           edge.width = sqrt(E(g)$weight)/(0.037*max(sqrt(E(g)$weight))),
+           edge.curved = F, 
+           axes = F,
+           edge.color = 'gray',
+           vertex.label = V(g)$common_name,
+           vertex.color =adjustcolor(V(g)$colors, alpha.f=0.90),
+           vertex.label.family = 'sans', 
+           # vertex.label.color = V(g)$colors, # to have same color as vertices
+           vertex.label.color = "gray25",
+           vertex.label.cex= 1.2, 
+           vertex.frame.color=NA
+           # vertex.label.dist = c(-9,-8,-9,-10),               # these can be adjusted manually to make it look nicer, which is super annoying
+           # vertex.label.degree = c(pi^(0.9),pi/5,pi/5,pi*1.1) # these can be adjusted manually to make it look nicer, which is super annoying
+      )
+    } #ifelse(vcount, ecount)
     dev.off()
-  } 
+  } # layout==c
+  
+  ## error message
   if(!(layout_type %in% c("c","fr","both"))){message("ERROR: don't recognize layout type. try again with [fr/c/both]")}
+  
+  ## progress message, for using plot function with lapply
+  if(verbose){
+    message("saved network graph image for ", port_group, " ", y)
+  }
   
 }

--- a/R/plot_simple_network.R
+++ b/R/plot_simple_network.R
@@ -10,11 +10,12 @@
 #' @param highlight which node to highlight in orange. Should specify from "common_name" vertex attribute.
 #' @param outdir directory where image files will be saved
 #' @param file_suffix string to be added to the suffix of the image file name. script will automatically name the files by port group, year, and layout type.
+#' @param verbose print out a message at the end of the function that includes the port name and year. Helpful when using lapply.
 #' @return Null. Will write plots directly to files
 #' @examples
 #' plot_network(tmpgraph, outdir="data/networks/participation/plots")
 #' @export
-plot_simple <- function(g, highlight="WOC_CRAB", outdir, file_suffix="_cciea"){
+plot_simple <- function(g, highlight="WOC_CRAB", outdir, file_suffix="_cciea", verbose=FALSE){
   port_group <- unique(V(g)$p)
   y <- unique(V(g)$year)
   l <-layout.circle(g)
@@ -23,6 +24,17 @@ plot_simple <- function(g, highlight="WOC_CRAB", outdir, file_suffix="_cciea"){
   tmpnames <- list(V(g)$common_name)
   V(g)$colors <- unlist(lapply(tmpnames, function (x) {ifelse(x==highlight,"darkorange1","gray25")}))
   png(here::here(outdir, paste0(port_group,"_", y,"_simple_dcrb",file_suffix,".png")),bg="transparent")
+  if(vcount(g) == 1 | ecount(g) == 0){
+    plot(g, vertex.size = V(g)$importance/(max(V(g)$importance)*0.025), 
+         layout = l, #where to put the nodes on the plot
+         # edge.width = sqrt(E(g)$weight)/(max(sqrt(E(g)$weight))*0.10),
+         edge.curved=F,
+         axes = F,
+         edge.color = 'gray68',
+         vertex.color = V(g)$colors, 
+         vertex.label = NA, 
+         vertex.frame.color=NA) #vertex.label.color = '#cb4b16'
+  } else{
   plot(g, vertex.size = V(g)$importance/(max(V(g)$importance)*0.025), 
        layout = l, #where to put the nodes on the plot
        edge.width = sqrt(E(g)$weight)/(max(sqrt(E(g)$weight))*0.10),
@@ -32,5 +44,9 @@ plot_simple <- function(g, highlight="WOC_CRAB", outdir, file_suffix="_cciea"){
        vertex.color = V(g)$colors, 
        vertex.label = NA, 
        vertex.frame.color=NA) #vertex.label.color = '#cb4b16'
+  }
   dev.off()
+  if(verbose){
+    message("saved network graph image for ", port_group, " ", y)
+  }
 }


### PR DESCRIPTION
revise plotting scripts so that networks without edges will not generate an error. adds an `ifelse()` statement that removes the `edge.width` plotting argument if the network does not have any edges. applies to both the main plotting function, *plot_network* and the simplified plotting function, *plot_simple*. 