### PR TITLE
fixes bug in participation network for loop

### DIFF
--- a/scripts/01_create_networks_cciea.Rmd
+++ b/scripts/01_create_networks_cciea.Rmd
@@ -296,7 +296,7 @@ for(y in years){
     
     g_nodestats <- g_nodestats %>%
       mutate(pcgroup = rep(iopac, times=dim(g_nodestats)[1]))
-    } #end 'else' close-g has > 0 vertex
+  
     
     
     #### SAVE NETWORK STATS OUTPUT ####
@@ -317,6 +317,8 @@ for(y in years){
     } else{
       mystats4 <- g_nodestats
     }
+    
+    } #end 'else' close-g has > 0 vertex
   } #end (p in myports)
   cat("\nfinished with all port groups in crab year ", y, "\n-----\n")
 } #end (y in years)


### PR DESCRIPTION
This commit fixes a bug that made some IOPAC ports have duplicate rows in the NetworkStats and NodeStats output files in some years. This turned out to be because the next port on the list for that year had no fish tickets in that year, so the `g_netstats` and `g_nodestats` temp dataframes weren't overwritten in the next iteration of the for loop and produced duplicate rows in the `mystats3` and `mystats4` objects. I fixed it by making sure that the temp dataframes were appended to `mystats3` and `mystats4` within the `else` statement for port-year combinations that produced a valid igraph object, not outside it.